### PR TITLE
docs: add readmes for server and web apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,90 +1,65 @@
 # Hex
 
-<a alt="Nx logo" href="https://nx.dev" target="_blank" rel="noreferrer"><img src="https://raw.githubusercontent.com/nrwl/nx/master/images/nx-logo.png" width="45"></a>
+This repository uses [Nx](https://nx.dev) to manage both the backend and the frontend.
 
-✨ Your new, shiny [Nx workspace](https://nx.dev) is almost ready ✨.
+- **server-lobby** – NestJS module containing server-side lobby features.
+- **web-lobby** – Angular web application.
 
-[Learn more about this workspace setup and its capabilities](https://nx.dev/nx-api/js?utm_source=nx_project&amp;utm_medium=readme&amp;utm_campaign=nx_projects) or run `npx nx graph` to visually explore what was created. Now, let's get you up to speed!
+## Prerequisites
 
-## Finish your CI setup
+- Node.js 18 or newer
+- npm or yarn
 
-[Click here to finish setting up your workspace!](https://cloud.nx.app/connect/BnZKSBESuH)
+## Installation
 
+Install all dependencies at the root of the workspace:
 
-## Generate a library
-
-```sh
-npx nx g @nx/js:lib packages/pkg1 --publishable --importPath=@my-org/pkg1
+```bash
+npm install
 ```
 
-## Run tasks
+## Running the NestJS server
 
-To build the library use:
+`server-lobby` is implemented as a NestJS module. To run a server that uses it, create a NestJS application and import `ServerLobbyModule`. After adding an application or a `serve` target, start it with:
 
-```sh
-npx nx build pkg1
+```bash
+npx nx serve server-lobby
 ```
 
-To run any task with Nx use:
+Run unit tests for the module with:
 
-```sh
-npx nx <target> <project-name>
+```bash
+npx nx test server-lobby
 ```
 
-These targets are either [inferred automatically](https://nx.dev/concepts/inferred-tasks?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects) or defined in the `project.json` or `package.json` files.
+## Running the Angular web application
 
-[More about running tasks in the docs &raquo;](https://nx.dev/features/run-tasks?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
+Start the development server:
 
-## Versioning and releasing
-
-To version and release the library use
-
-```
-npx nx release
+```bash
+npx nx serve web-lobby
 ```
 
-Pass `--dry-run` to see what would happen without actually releasing the library.
+The application will be available at [http://localhost:4200](http://localhost:4200).
 
-[Learn more about Nx release &raquo;](https://nx.dev/features/manage-releases?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
+## Building
 
-## Keep TypeScript project references up to date
+Build the Angular app for production:
 
-Nx automatically updates TypeScript [project references](https://www.typescriptlang.org/docs/handbook/project-references.html) in `tsconfig.json` files to ensure they remain accurate based on your project dependencies (`import` or `require` statements). This sync is automatically done when running tasks such as `build` or `typecheck`, which require updated references to function correctly.
-
-To manually trigger the process to sync the project graph dependencies information to the TypeScript project references, run the following command:
-
-```sh
-npx nx sync
+```bash
+npx nx build web-lobby
 ```
 
-You can enforce that the TypeScript project references are always in the correct state when running in CI by adding a step to your CI job configuration that runs the following command:
+Build the NestJS module:
 
-```sh
-npx nx sync:check
+```bash
+npx nx build server-lobby
 ```
 
-[Learn more about nx sync](https://nx.dev/reference/nx-commands#sync)
+## Testing
 
+Run unit tests for all projects:
 
-[Learn more about Nx on CI](https://nx.dev/ci/intro/ci-with-nx#ready-get-started-with-your-provider?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-
-## Install Nx Console
-
-Nx Console is an editor extension that enriches your developer experience. It lets you run tasks, generate code, and improves code autocompletion in your IDE. It is available for VSCode and IntelliJ.
-
-[Install Nx Console &raquo;](https://nx.dev/getting-started/editor-setup?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-
-## Useful links
-
-Learn more:
-
-- [Learn more about this workspace setup](https://nx.dev/nx-api/js?utm_source=nx_project&amp;utm_medium=readme&amp;utm_campaign=nx_projects)
-- [Learn about Nx on CI](https://nx.dev/ci/intro/ci-with-nx?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-- [Releasing Packages with Nx release](https://nx.dev/features/manage-releases?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-- [What are Nx plugins?](https://nx.dev/concepts/nx-plugins?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
-
-And join the Nx community:
-- [Discord](https://go.nx.dev/community)
-- [Follow us on X](https://twitter.com/nxdevtools) or [LinkedIn](https://www.linkedin.com/company/nrwl)
-- [Our Youtube channel](https://www.youtube.com/@nxdevtools)
-- [Our blog](https://nx.dev/blog?utm_source=nx_project&utm_medium=readme&utm_campaign=nx_projects)
+```bash
+npx nx test
+```

--- a/apps/server-lobby/README.md
+++ b/apps/server-lobby/README.md
@@ -1,7 +1,38 @@
 # server-lobby
 
-This library was generated with [Nx](https://nx.dev).
+NestJS module providing lobby functionality.
+
+## Setup
+
+Install dependencies in the repository root:
+
+```bash
+npm install
+```
+
+## Building
+
+```bash
+npx nx build server-lobby
+```
 
 ## Running unit tests
 
-Run `nx test server-lobby` to execute the unit tests via [Jest](https://jestjs.io).
+```bash
+npx nx test server-lobby
+```
+
+## Using in a NestJS server
+
+This library exports `ServerLobbyModule`. To run a NestJS server that uses it, create an application and import the module:
+
+```ts
+import { NestFactory } from '@nestjs/core';
+import { ServerLobbyModule } from '@hex/source/server-lobby';
+
+async function bootstrap() {
+  const app = await NestFactory.create(ServerLobbyModule);
+  await app.listen(3333);
+}
+bootstrap();
+```

--- a/apps/web-lobby/README.md
+++ b/apps/web-lobby/README.md
@@ -1,0 +1,31 @@
+# web-lobby
+
+Angular web application for the lobby.
+
+## Setup
+
+Install dependencies in the repository root:
+
+```bash
+npm install
+```
+
+## Running in development
+
+```bash
+npx nx serve web-lobby
+```
+
+The application will be available at [http://localhost:4200](http://localhost:4200).
+
+## Building
+
+```bash
+npx nx build web-lobby
+```
+
+## Running unit tests
+
+```bash
+npx nx test web-lobby
+```


### PR DESCRIPTION
## Summary
- add workspace README with instructions for NestJS server and Angular web app
- document server-lobby module usage
- add README for Angular web-lobby application

## Testing
- `npx nx test server-lobby`
- `npx nx test web-lobby`


------
https://chatgpt.com/codex/tasks/task_e_68b7306b208c8322954bf15e651b64f0